### PR TITLE
Enable thumbnail support

### DIFF
--- a/src/nextjs-framework/editor/widget-framework/widget-editor-metadata.ts
+++ b/src/nextjs-framework/editor/widget-framework/widget-editor-metadata.ts
@@ -4,4 +4,5 @@ export interface EditorMetadata {
     EmptyIconText?: string;
     EmptyIconAction?: 'Edit' | 'None';
     EmptyIcon?: string;
+    ThumbnailUrl?: string;
 }

--- a/src/nextjs-framework/services/renderer-contract.ts
+++ b/src/nextjs-framework/services/renderer-contract.ts
@@ -66,7 +66,8 @@ export class RendererContractImpl implements RendererContract {
             if ((widgetEntry.selectorCategory === args.category) || (!widgetEntry.selectorCategory && args.category === 'Content')) {
                 filteredWidgets.push({
                     name: key,
-                    title: widgetEntry.editorMetadata?.Title || key
+                    title: widgetEntry.editorMetadata?.Title || key,
+                    thumbnailUrl: widgetEntry.editorMetadata?.ThumbnailUrl
                 });
             }
         });


### PR DESCRIPTION
Sample usage for the breadcrumb property, when having a file in public/assets/thumbnail-default.png

``` typescript

export const widgetRegistry: WidgetRegistry = {
    widgets: {
        'SitefinityBreadcrumb':  <any>{
            designerMetadata: sitefinityBreadcrumbJson,
            componentType: Breadcrumb,
            editorMetadata: {
                Title: 'Breadcrumb',
                ThumbnailUrl: '/assets/thumbnail-default.png'
            },
            ssr: true
        },

```